### PR TITLE
inhibiting bugprone-exception-escape checks.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,6 +13,7 @@ Checks: "*,
         -readability-avoid-const-params-in-decls,
         -cppcoreguidelines-non-private-member-variables-in-classes,
         -misc-non-private-member-variables-in-classes,
+        -bugprone-exception-escape,
 "
 WarningsAsErrors: ''
 HeaderFilterRegex: ''


### PR DESCRIPTION
The root clang-tidy configuration file has bugprone-exception-escape inhibited.
This is to prevent the the windows jobs from raising exception errors in trivial functions.